### PR TITLE
some diffs between Centos 7 and 8

### DIFF
--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -4,10 +4,16 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <bits/stdint-uintn.h>
+//#include <bits/stdint-uintn.h>
 #include <ctype.h>
 #include <getopt.h>
 #include <time.h>
+
+
+#ifndef  uint32_t
+typedef unsigned int uint32_t;
+#endif
+
 #define WORKFLOW_NAMES_MAX	4
 
 


### PR DESCRIPTION
Missing include file when dealing with Centos 7 and opposed to Centos 8.