### PR TITLE
Nic tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ There are also two relevant directories here:
 -	go to assess-tuning directory and run ```make```
 -	For a quick test:
 	*	type ```sudo ./dtnmenu``` to run with a menu interaction
+	*	type ```sudo ./dtnmenu <device>``` to also configure a device
 	*	you will get output on your screen with the menu interaction
 	*	type ```sudo ./dtn_tune``` to run without menu interaction
 	* 	/tmp/tuningLog will contain the output from the last run

--- a/assess-tuning/common_irq_affinity.sh
+++ b/assess-tuning/common_irq_affinity.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Mellanox Technologies. All rights reserved.
+#
+# This Software is licensed under one of the following licenses:
+#
+# 1) under the terms of the "Common Public License 1.0" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/cpl.php.
+#
+# 2) under the terms of the "The BSD License" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/bsd-license.php.
+#
+# 3) under the terms of the "GNU General Public License (GPL) Version 2" a
+#    copy of which is available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/gpl-license.php.
+#
+# Licensee has the right to choose one of the above licenses.
+#
+# Redistributions of source code must retain the above copyright
+# notice and one of the license notices.
+#
+# Redistributions in binary form must reproduce both the above copyright
+# notice, one of the license notices in the documentation
+# and/or other materials provided with the distribution.
+#
+
+function add_comma_every_eight
+{
+        echo " $1 " | sed -r ':L;s=\b([0-9]+)([0-9]{8})\b=\1,\2=g;t L'
+}
+
+function int2hex
+{
+	CHUNKS=$(( $1/64 ))
+	COREID=$1
+	HEX=""
+ 	for (( CHUNK=0; CHUNK<${CHUNKS} ; CHUNK++ ))
+	do
+		HEX=$HEX"0000000000000000"
+		COREID=$((COREID-64))
+	done
+        printf "%x$HEX" $(echo $((2**$COREID)) )
+}
+
+
+function core_to_affinity
+{
+	echo $( add_comma_every_eight $( int2hex $1) )
+}
+
+function get_irq_list
+{
+	interface=$1
+	infiniband_device_irqs_path="/sys/class/infiniband/$interface/device/msi_irqs"
+	net_device_irqs_path="/sys/class/net/$interface/device/msi_irqs"
+	interface_in_proc_interrupts=$( cat /proc/interrupts | egrep "$interface[^0-9,a-z,A-Z]" | awk '{print $1}' | sed 's/://' )
+	if [ -d $infiniband_device_irqs_path ]; then
+		irq_list=$( /bin/ls $infiniband_device_irqs_path )
+	elif [ "$interface_in_proc_interrupts" != "" ]; then
+		irq_list=$interface_in_proc_interrupts
+	elif [ -d $net_device_irqs_path ]; then
+		irq_list=$( /bin/ls $net_device_irqs_path )
+	else 
+		echo "Error - interface or device \"$interface\" does not exist" 1>&2
+		exit 1
+	fi
+	echo $irq_list
+}
+
+function show_irq_affinity
+{
+	irq_num=$1
+	smp_affinity_path="/proc/irq/$irq_num/smp_affinity"
+        if [ -f $smp_affinity_path ]; then
+                echo -n "$irq_num: "
+                cat $smp_affinity_path
+        fi
+}
+
+function show_irq_affinity_hints
+{
+	irq_num=$1
+	affinity_hint_path="/proc/irq/$irq_num/affinity_hint"
+        if [ -f $affinity_hint_path ]; then
+                echo -n "$irq_num: "
+                cat $affinity_hint_path
+        fi
+}
+
+function set_irq_affinity
+{
+	irq_num=$1
+	affinity_mask=$2
+	smp_affinity_path="/proc/irq/$irq_num/smp_affinity"
+        if [ -f $smp_affinity_path ]; then
+                echo $affinity_mask > $smp_affinity_path
+        fi
+}
+
+function is_affinity_hint_set
+{
+	irq_num=$1
+	hint_not_set=0
+	affinity_hint_path="/proc/irq/$irq_num/affinity_hint"
+	if [ -f $affinity_hint_path ]; then
+		TOTAL_CHAR=$( wc -c < $affinity_hint_path  )
+		NUM_OF_COMMAS=$( grep -o "," $affinity_hint_path | wc -l )
+		NUM_OF_ZERO=$( grep -o "0" $affinity_hint_path | wc -l )
+		NUM_OF_F=$( grep -i -o "f" $affinity_hint_path | wc -l )
+		if [[ $((TOTAL_CHAR-1-NUM_OF_COMMAS)) -eq $NUM_OF_ZERO || $((TOTAL_CHAR-1-NUM_OF_COMMAS)) -eq $NUM_OF_F ]]; then
+			hint_not_set=1
+		fi
+	else
+		hint_not_set=1
+	fi
+	return $hint_not_set
+}

--- a/assess-tuning/dtn_menu.sh
+++ b/assess-tuning/dtn_menu.sh
@@ -139,8 +139,6 @@ apply_recommended_bios_settings()
 			count=`expr $count + 1`
 		done	
 		
-		echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
-
 		rm -f /tmp/tun_app_command
 		rm -f /tmp/applyBiosDefFile
 	else

--- a/assess-tuning/dtn_menu.sh
+++ b/assess-tuning/dtn_menu.sh
@@ -42,13 +42,13 @@ prune_logs()
 	return 0
 }
 
-apply_recommended_settings()
+apply_recommended_kernel_settings()
 {
 	clear_screen
-	if [ -f  /tmp/applyDefFile ]
+	if [ -f  /tmp/applyKernelDefFile ]
 	then
 		printf '\n\t%s\n' \
-			"You are attempting to apply the Last Tuning Recommendations" 
+			"You are attempting to apply the Kernel Tuning Recommendations" 
 		printf '\n\t%s (y/n): ' \
 			"Do you wish to continue? "
 		read answer
@@ -61,17 +61,17 @@ apply_recommended_settings()
 		sysctlmodified=0
 		
 		printf '\n\t%s (y/n): ' \
-			"Do you wish to apply the Tuning Recommendations permanently? " 
+			"Do you wish to apply the Kernel Tuning Recommendations permanently? " 
 		read answer
 		if [ "$answer" != 'y' -a "$answer" != 'Y' ]
 		then
-			printf '\n###%s\n\n' "Applying Tuning Recommendations until a reboot..."
+			printf '\n###%s\n\n' "Applying Kernel Tuning Recommendations until a reboot..."
 		else
-			printf '\n###%s\n\n' "Applying Tuning Recommendations Permanently..."
+			printf '\n###%s\n\n' "Applying Kernel Tuning Recommendations Permanently..."
 			sysctlmodified=1
 		fi
 
-		nlines=`sed -n '1p' /tmp/applyDefFile`	
+		nlines=`sed -n '1p' /tmp/applyKernelDefFile`	
 		count=2
 
 		if [ ${sysctlmodified} -eq 1 ]
@@ -81,7 +81,7 @@ apply_recommended_settings()
 
 		while [ ${count} -lt ${nlines} ]
 		do
-			linenum=`sed -n "${count}p" /tmp/applyDefFile`
+			linenum=`sed -n "${count}p" /tmp/applyKernelDefFile`
 			echo $linenum > /tmp/tun_app_command
 			sh /tmp/tun_app_command
 		
@@ -100,9 +100,162 @@ apply_recommended_settings()
 		fi
 
 		rm -f /tmp/tun_app_command
-		rm -f /tmp/applyDefFile
+		rm -f /tmp/applyKernelDefFile
+	else
+		printf '\n###%s\n\n' "Sorry. You do not have any Kernel Tuning Recommendations to apply..."
+
+	fi
+    enter_to_continue
+	return 0
+}
+
+apply_recommended_bios_settings()
+{
+	clear_screen
+	if [ -f  /tmp/applyBiosDefFile ]
+	then
+		printf '\n\t%s\n' \
+			"You are attempting to apply the BIOS Tuning Recommendations" 
+		printf '\n\t%s (y/n): ' \
+			"Do you wish to continue? "
+		read answer
+		if [ "$answer" != 'y' -a "$answer" != 'Y' ]
+		then
+			enter_to_continue
+			return 0
+		fi
+		
+		sysctlmodified=0
+
+		nlines=`sed -n '1p' /tmp/applyBiosDefFile`	
+		count=2
+
+		if [ ${sysctlmodified} -eq 1 ]
+		then
+			echo "#Applying BIOS Tuning Recommendations..." 
+		fi
+
+		while [ ${count} -lt ${nlines} ]
+		do
+			linenum=`sed -n "${count}p" /tmp/applyBiosDefFile`
+			echo $linenum > /tmp/tun_app_command
+			sh /tmp/tun_app_command
+		
+			if [ ${sysctlmodified} -eq 1 ]
+			then
+			echo "$linenum >> /etc/sysctl.conf" > /tmp/tun_app_command
+			sh /tmp/tun_app_command
+			fi
+
+			count=`expr $count + 1`
+		done	
+		
+		if [ ${sysctlmodified} -eq 1 ]
+		then
+			echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
+		fi
+
+		rm -f /tmp/tun_app_command
+		rm -f /tmp/applyBiosDefFile
+	else
+		printf '\n###%s\n\n' "Sorry. You do not have any BIOS Tuning Recommendations to apply..."
+
+	fi
+    enter_to_continue
+	return 0
+}
+
+apply_recommended_nic_settings()
+{
+	clear_screen
+	if [ -f  /tmp/applyNicDefFile ]
+	then
+		printf '\n\t%s\n' \
+			"You are attempting to apply the NIC Tuning Recommendations" 
+		printf '\n\t%s (y/n): ' \
+			"Do you wish to continue? "
+		read answer
+		if [ "$answer" != 'y' -a "$answer" != 'Y' ]
+		then
+			enter_to_continue
+			return 0
+		fi
+
+		nlines=`sed -n '1p' /tmp/applyNicDefFile`	
+		count=2
+
+		echo "#Applying NIC Tuning Recommendations..." 
+
+		while [ ${count} -lt ${nlines} ]
+		do
+			linenum=`sed -n "${count}p" /tmp/applyNicDefFile`
+			echo $linenum > /tmp/tun_app_command
+			sh /tmp/tun_app_command
+			count=`expr $count + 1`
+		done	
+		
+		echo "#Finished Applying NIC Tuning Recommendations..." 
+
+		rm -f /tmp/tun_app_command
+		rm -f /tmp/applyNicDefFile
 	else
 		printf '\n###%s\n\n' "Sorry. You do not have any Tuning Recommendations to apply..."
+
+	fi
+    enter_to_continue
+	return 0
+}
+
+apply_all_recommended_settings()
+{
+	clear_screen
+	if [ -f  /tmp/applyAllDefFile ]
+	then
+		printf '\n\t%s\n' \
+			"You are attempting to apply All Tuning Recommendations" 
+		printf '\n\t%s (y/n): ' \
+			"Do you wish to continue? "
+		read answer
+		if [ "$answer" != 'y' -a "$answer" != 'Y' ]
+		then
+			enter_to_continue
+			return 0
+		fi
+
+		sysctlmodified=0
+		
+		nlines=`sed -n '1p' /tmp/applyAllDefFile`	
+		count=2
+
+		if [ ${sysctlmodified} -eq 1 ]
+		then
+			echo "#Applying All Tuning Recommendations..." >> /etc/sysctl.conf	
+		fi
+
+		while [ ${count} -lt ${nlines} ]
+		do
+			linenum=`sed -n "${count}p" /tmp/applyAllDefFile`
+			echo $linenum > /tmp/tun_app_command
+			sh /tmp/tun_app_command
+		
+			if [ ${sysctlmodified} -eq 1 ]
+			then
+			echo "$linenum >> /etc/sysctl.conf" > /tmp/tun_app_command
+			sh /tmp/tun_app_command
+			fi
+
+			count=`expr $count + 1`
+		done	
+		
+		if [ ${sysctlmodified} -eq 1 ]
+		then
+			echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
+		fi
+
+		rm -f /tmp/tun_app_command
+		rm -f /tmp/applyAllDefFile
+	else
+		printf '\n###%s\n\n' "Sorry. You do not have any All Tuning Recommendations to apply..."
 
 	fi
     enter_to_continue
@@ -150,13 +303,16 @@ Usage:\\t[sudo ./dtnmenu]\\t\\t- Configure Tunables \\n\
 	while  [ $repeat_main = 1 ]
 	do
 		clear_screen
-		printf '\n\n\t%s\n\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s' \
+		printf '\n\n\t%s\n\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s' \
 			"DTN Tuning Utility" \
 			"1) Run DTN Tune" \
-			"2) Apply Last Recommended Tuning Values" \
-			"3) Prune Old Logs" \
-			"4) Escape to Linux Shell" \
-			"5) Exit" \
+			"2) Apply Recommended Kernel Tuning Values Only" \
+			"3) Apply Recommended BIOS Tuning Values Only" \
+			"4) Apply Recommended NIC Tuning Values Only" \
+			"5) Apply All Recommended Tuning Values" \
+			"6) Prune Old Logs" \
+			"7) Escape to Linux Shell" \
+			"8) Exit" \
 			"$select_choice"
 
 		read answer
@@ -165,18 +321,27 @@ Usage:\\t[sudo ./dtnmenu]\\t\\t- Configure Tunables \\n\
 				run_dtntune "$1"
 				;;
 			2)
-				apply_recommended_settings
+				apply_recommended_kernel_settings
 				;;
 			3)
-				prune_logs
+				apply_recommended_bios_settings
 				;;
 			4)
+				apply_recommended_nic_settings
+				;;
+			5)
+				apply_all_recommended_settings
+				;;
+			6)
+				prune_logs
+				;;
+			7)
 				clear_screen
 				$SHELL
 				clear_screen
 				enter_to_continue
 				;;
-			q|5)
+			q|8)
 				clear_screen
 				exit 0
 				;;

--- a/assess-tuning/dtn_menu.sh
+++ b/assess-tuning/dtn_menu.sh
@@ -215,9 +215,6 @@ apply_all_recommended_settings()
 		apply_recommended_nic_settings
 
 		echo "#Finished Applying All Tuning Recommendations..."	
-
-		rm -f /tmp/tun_app_command
-		rm -f /tmp/applyAllDefFile
 	else
 		printf '\n###%s\n\n' "Sorry. You do not have any All Tuning Recommendations to apply..."
 

--- a/assess-tuning/dtn_menu.sh
+++ b/assess-tuning/dtn_menu.sh
@@ -125,35 +125,21 @@ apply_recommended_bios_settings()
 			return 0
 		fi
 		
-		sysctlmodified=0
 
 		nlines=`sed -n '1p' /tmp/applyBiosDefFile`	
 		count=2
 
-		if [ ${sysctlmodified} -eq 1 ]
-		then
-			echo "#Applying BIOS Tuning Recommendations..." 
-		fi
+		echo "#Applying BIOS Tuning Recommendations..." 
 
 		while [ ${count} -lt ${nlines} ]
 		do
 			linenum=`sed -n "${count}p" /tmp/applyBiosDefFile`
 			echo $linenum > /tmp/tun_app_command
-			sh /tmp/tun_app_command
-		
-			if [ ${sysctlmodified} -eq 1 ]
-			then
-			echo "$linenum >> /etc/sysctl.conf" > /tmp/tun_app_command
-			sh /tmp/tun_app_command
-			fi
-
+			sh /tmp/tun_app_command 1>/dev/null
 			count=`expr $count + 1`
 		done	
 		
-		if [ ${sysctlmodified} -eq 1 ]
-		then
-			echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
-		fi
+		echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
 
 		rm -f /tmp/tun_app_command
 		rm -f /tmp/applyBiosDefFile
@@ -209,7 +195,7 @@ apply_recommended_nic_settings()
 apply_all_recommended_settings()
 {
 	clear_screen
-	if [ -f  /tmp/applyAllDefFile ]
+	if [ -f  /tmp/applyKernelDefFile -o -f /tmp/applyBiosDefFile -o -f  /tmp/applyNicDefFile ]
 	then
 		printf '\n\t%s\n' \
 			"You are attempting to apply All Tuning Recommendations" 
@@ -222,35 +208,13 @@ apply_all_recommended_settings()
 			return 0
 		fi
 
-		sysctlmodified=0
-		
-		nlines=`sed -n '1p' /tmp/applyAllDefFile`	
-		count=2
+		echo "#Applying All Tuning Recommendations..." 
 
-		if [ ${sysctlmodified} -eq 1 ]
-		then
-			echo "#Applying All Tuning Recommendations..." >> /etc/sysctl.conf	
-		fi
+		apply_recommended_kernel_settings
+		apply_recommended_bios_settings
+		apply_recommended_nic_settings
 
-		while [ ${count} -lt ${nlines} ]
-		do
-			linenum=`sed -n "${count}p" /tmp/applyAllDefFile`
-			echo $linenum > /tmp/tun_app_command
-			sh /tmp/tun_app_command
-		
-			if [ ${sysctlmodified} -eq 1 ]
-			then
-			echo "$linenum >> /etc/sysctl.conf" > /tmp/tun_app_command
-			sh /tmp/tun_app_command
-			fi
-
-			count=`expr $count + 1`
-		done	
-		
-		if [ ${sysctlmodified} -eq 1 ]
-		then
-			echo "#End of tuningMod modifications" >> /etc/sysctl.conf	
-		fi
+		echo "#Finished Applying All Tuning Recommendations..."	
 
 		rm -f /tmp/tun_app_command
 		rm -f /tmp/applyAllDefFile

--- a/assess-tuning/dtn_menu.sh
+++ b/assess-tuning/dtn_menu.sh
@@ -123,17 +123,29 @@ logcount=
 	else
 		echo 0 > /tmp/tuningLog.count
 	fi
-	./dtn_tune
+	./dtn_tune $1
+
 	if [ $? = 0 ]
-   	then
+	then	
 		more -d /tmp/tuningLog	
 		printf '\n###%s' "This output has been saved in /tmp/tuningLog"
+	else
+		more -d /tmp/tuningLog	
+		printf '\n###%s' "This output has been saved in /tmp/tuningLog"
+		echo >&2
+    	echo >&2 $UsageString
 	fi
 	enter_to_continue
 	return 0
 }
 
+UsageString="\
+Usage:\\t[sudo ./dtnmenu]\\t\\t- Configure Tunables \\n\
+\\t[sudo ./dtnmenu <device>]\\t- Configure Tunables and Device"
+
 # main execution thread
+
+	
 	repeat_main=1
 	while  [ $repeat_main = 1 ]
 	do
@@ -150,7 +162,7 @@ logcount=
 		read answer
 		case "$answer" in
 			1)
-				run_dtntune
+				run_dtntune "$1"
 				;;
 			2)
 				apply_recommended_settings

--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -1849,9 +1849,7 @@ dnflow_support:
 	fprintf(tunLogPtr,"%s", "flow_control_rx_tx"); //redundancy for visual
 	fprintf(tunLogPtr,"%*s", vPad, "not supported");
 	fprintf(tunLogPtr,"%26s %20s\n", "not supported", "na");
-
-    fclose(nicCfgFPtr);
-    system("rm -f /tmp/NIC.cfgfile"); //remove file after use
+	system("rm -f /tmp/NIC.cfgfile"); //remove file after use
 
 	return;
 }

--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -342,9 +342,11 @@ typedef struct {
  */
 #define NUM_SYSTEM_SETTINGS	100
 #define MAX_SIZE_SYSTEM_SETTING_STRING	768
-int aApplyDefTunCount = 0;
+int aApplyKernelDefTunCount = 0;
+int aApplyNicDefTunCount = 0;
 int vModifySysctlFile = 0;
-char aApplyDefTun2DArray[NUM_SYSTEM_SETTINGS][MAX_SIZE_SYSTEM_SETTING_STRING];
+char aApplyKernelDefTun2DArray[NUM_SYSTEM_SETTINGS][MAX_SIZE_SYSTEM_SETTING_STRING];
+char aApplyNicDefTun2DArray[NUM_SYSTEM_SETTINGS][MAX_SIZE_SYSTEM_SETTING_STRING];
 
 #define TUNING_NUMS_10GandUnder	9
 /* Must change TUNING_NUMS_10GandUnder if adding more to the array below */
@@ -532,8 +534,8 @@ void fDoSystemTuning(void)
 										{
 											//Save in Case Operator want to apply from menu
 											sprintf(aApplyDefTun,"sysctl -w %s=%d",setting,aTuningNumsToUse[count].minimum);
-											memcpy(aApplyDefTun2DArray[aApplyDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
-											aApplyDefTunCount++;
+											memcpy(aApplyKernelDefTun2DArray[aApplyKernelDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
+											aApplyKernelDefTunCount++;
 										}
 								}
 						}
@@ -616,8 +618,8 @@ void fDoSystemTuning(void)
 											{
 												//Save in Case Operator want to apply from menu
 												sprintf(aApplyDefTun,"sysctl -w %s=\"%s %s %s\"",setting, strValmin, strValdef, strValmax);
-												memcpy(aApplyDefTun2DArray[aApplyDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
-												aApplyDefTunCount++;
+												memcpy(aApplyKernelDefTun2DArray[aApplyKernelDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
+												aApplyKernelDefTunCount++;
 											}
 									}
 									else
@@ -772,11 +774,11 @@ void fDoSystemTuning(void)
 								}
 							}
 							else
-				                               {
+								{
 									//Save in Case Operator want to apply from menu
 									sprintf(aApplyDefTun,"sysctl -w %s=%s",setting,aStringval[aTuningNumsToUse[count].minimum]);
-									memcpy(aApplyDefTun2DArray[aApplyDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
-									aApplyDefTunCount++;
+									memcpy(aApplyKernelDefTun2DArray[aApplyKernelDefTunCount], aApplyDefTun, strlen(aApplyDefTun));
+									aApplyKernelDefTunCount++;
 								}
 						}
 						else
@@ -1066,6 +1068,13 @@ void fDoTxQueueLen()
 								printf("%s\n",aNicSetting);
 								//system(aNicSetting);
 							}
+							else
+								{
+									//Save in Case Operator want to apply from menu
+									sprintf(aNicSetting,"ifconfig %s txqueuelen %d", netDevice, rec_txqueuelen);
+									memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+									aApplyNicDefTunCount++;
+								}
 						}
 						else
 							fprintf(tunLogPtr,"%26d %20s\n", rec_txqueuelen, "na");
@@ -1202,6 +1211,13 @@ void fDoRingBufferSize()
 										printf("%s\n",aNicSetting);
 										//system(aNicSetting);
 									}
+									else
+										{
+											//Save in Case Operator want to apply from menu
+											sprintf(aNicSetting,"ethtool -G %s rx %d", netDevice, cfg_max_val);
+											memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+											aApplyNicDefTunCount++;
+										}
 								}
 								else
 									fprintf(tunLogPtr,"%26d %20s\n", cfg_max_val, "na");
@@ -1223,6 +1239,13 @@ void fDoRingBufferSize()
 										printf("%s\n",aNicSetting);
 										//system(aNicSetting);
 									}
+									else
+										{
+											//Save in Case Operator want to apply from menu
+											sprintf(aNicSetting,"ethtool -G %s tx %d", netDevice, cfg_max_val);
+											memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+											aApplyNicDefTunCount++;
+										}
 								}
 								else
 									fprintf(tunLogPtr,"%26d %20s\n", cfg_max_val, "na");
@@ -1302,6 +1325,13 @@ void fDoLRO()
 						printf("%s\n",aNicSetting);
 						//system(aNicSetting);
 					}
+					else
+						{
+							//Save in Case Operator want to apply from menu
+							sprintf(aNicSetting,"ethtool -K %s lro %s", netDevice, recommended_val);
+							memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+							aApplyNicDefTunCount++;
+						}
 				}
 				else
 					fprintf(tunLogPtr,"%26s %20s\n", recommended_val, "na");
@@ -1373,6 +1403,13 @@ void fDoMTU()
 								printf("%s\n",aNicSetting);
 								//system(aNicSetting);
 							}
+							else
+								{
+									//Save in Case Operator want to apply from menu
+									sprintf(aNicSetting,"sudo ip link set dev %s mtu %d", netDevice, rec_mtu);
+									memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+									aApplyNicDefTunCount++;
+								}
 						}
 						else
 							fprintf(tunLogPtr,"%26d %20s\n", cfg_val, "na");
@@ -1402,7 +1439,7 @@ void fDoTcQdiscFq()
 	struct stat sb;
 	int found = 0;
 	char aQdiscVal[512];
-	char aNicSetting[512];
+	char aNicSetting[1024];
 	FILE *nicCfgFPtr = 0;
 			
 	sprintf(aNicSetting,"tc qdisc show dev %s root 2>/dev/null > /tmp/NIC.cfgfile",netDevice);
@@ -1463,10 +1500,17 @@ void fDoTcQdiscFq()
 					if (gApplyNicTuning == 'y')
 					{
 						//Apply Inital DefSys Tuning
-						sprintf(aNicSetting,"tc qdisc del dev %s root fq; tc qdisc add dev %s root fq", netDevice, netDevice);
+						sprintf(aNicSetting,"tc qdisc del dev %s root %s 2>/dev/null; tc qdisc add dev %s root fq", netDevice, aQdiscVal, netDevice);
 						printf("%s\n",aNicSetting);
 						//system(aNicSetting);
 					}
+					else
+						{
+							//Save in Case Operator want to apply from menu
+							sprintf(aNicSetting,"tc qdisc del dev %s root %s 2>/dev/null; tc qdisc add dev %s root fq", netDevice, aQdiscVal, netDevice);
+							memcpy(aApplyNicDefTun2DArray[aApplyNicDefTunCount], aNicSetting, strlen(aNicSetting));
+							aApplyNicDefTunCount++;
+						}
 				}
 				else
 					fprintf(tunLogPtr,"%26s %20s\n", aQdiscVal, "na");
@@ -1575,26 +1619,51 @@ int main(int argc, char **argv)
 	{
 		// in case the user wants to apply recommended settings interactively
 		int x =0;
-		FILE * fApplyDefTunPtr = 0;	
-		if (aApplyDefTunCount)
+		FILE * fApplyKernelDefTunPtr = 0;	
+		if (aApplyKernelDefTunCount)
 		{
-			fApplyDefTunPtr = fopen("/tmp/applyDefFile","w"); //open and close to wipe out file - other ways to do this, but this should work...
-			if (!fApplyDefTunPtr)
+			fApplyKernelDefTunPtr = fopen("/tmp/applyKernelDefFile","w"); //open and close to wipe out file - other ways to do this, but this should work...
+			if (!fApplyKernelDefTunPtr)
 			{
 				int save_errno = errno;
-				fprintf(tunLogPtr, "%s %s: Could not open */tmp/applyDefFile* for writing, errno = %d***\n", ctime_buf, phase2str(current_phase), save_errno);
+				fprintf(tunLogPtr, "%s %s: Could not open */tmp/applyKernelDefFile* for writing, errno = %d***\n", ctime_buf, phase2str(current_phase), save_errno);
 				goto leave;
 			}
 
-			fprintf(fApplyDefTunPtr, "%d\n",aApplyDefTunCount+2);
+			fprintf(fApplyKernelDefTunPtr, "%d\n",aApplyKernelDefTunCount+2);
 
-			for (x = 0; x < aApplyDefTunCount; x++)
-				fprintf(fApplyDefTunPtr, "%s\n",aApplyDefTun2DArray[x]);
+			for (x = 0; x < aApplyKernelDefTunCount; x++)
+				fprintf(fApplyKernelDefTunPtr, "%s\n",aApplyKernelDefTun2DArray[x]);
 				
-			fclose(fApplyDefTunPtr);	
+			fclose(fApplyKernelDefTunPtr);	
 		}
 		else
-			system("rm -f /tmp/applyDefFile");	//There is a way this can be left around by mistake
+			system("rm -f /tmp/applyKernelDefFile");	//There is a way this can be left around by mistake
+	}
+
+	{
+		// in case the user wants to apply recommended settings interactively
+		int x =0;
+		FILE * fApplyNicDefTunPtr = 0;	
+		if (aApplyNicDefTunCount)
+		{
+			fApplyNicDefTunPtr = fopen("/tmp/applyNicDefFile","w"); //open and close to wipe out file - other ways to do this, but this should work...
+			if (!fApplyNicDefTunPtr)
+			{
+				int save_errno = errno;
+				fprintf(tunLogPtr, "%s %s: Could not open */tmp/applyNicDefFile* for writing, errno = %d***\n", ctime_buf, phase2str(current_phase), save_errno);
+				goto leave;
+			}
+
+			fprintf(fApplyNicDefTunPtr, "%d\n",aApplyNicDefTunCount+2);
+
+			for (x = 0; x < aApplyNicDefTunCount; x++)
+				fprintf(fApplyNicDefTunPtr, "%s\n",aApplyNicDefTun2DArray[x]);
+				
+			fclose(fApplyNicDefTunPtr);	
+		}
+		else
+			system("rm -f /tmp/applyNicDefFile");	//There is a way this can be left around by mistake
 	}
 
 leave:

--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -1893,6 +1893,8 @@ void fDoNicTuning(void)
  * some systems dont dont show it though...
 */
 
+/* numactl --hardware will show number of cores per numa node */
+
 	fprintf(tunLogPtr,"\n%s %s: *****************End of Evaluate NIC configuration*****************\n", ctime_buf, phase2str(current_phase));
 	fprintf(tunLogPtr,  "%s %s: -------------------------------------------------------------------\n\n", ctime_buf, phase2str(current_phase));
 

--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -1968,7 +1968,6 @@ int main(int argc, char **argv)
 	{
 		fDoGetDeviceCap();
 		numaNode = fDoGetNuma();
-			fprintf(tunLogPtr, "%s %s: NUMA NODE is  *%d***\n", ctime_buf, phase2str(current_phase), numaNode);
 	}
 
 	fDoSystemTuning();

--- a/assess-tuning/dtnmenu
+++ b/assess-tuning/dtnmenu
@@ -9,7 +9,7 @@
 # main execution thread
     if [ `id -u` = 0 ]
     then
-		sh dtn_menu.sh
+		sh dtn_menu.sh $1
 	else
         printf '\n***%s\n' "You must be superuser to run dtnmenu..."
         printf '***%s\n\n' "Exiting..."

--- a/assess-tuning/gdv_100.sh
+++ b/assess-tuning/gdv_100.sh
@@ -11,3 +11,7 @@ sysctl net.core.default_qdisc >> /tmp/current_config.orig
 
 sysctl net.ipv4.tcp_rmem >> /tmp/current_config.orig
 sysctl net.ipv4.tcp_wmem >> /tmp/current_config.orig
+
+sysctl net.core.netdev_max_backlog >> /tmp/current_config.orig
+sysctl net.ipv4.tcp_no_metrics_save >> /tmp/current_config.orig
+

--- a/assess-tuning/set_irq_affinity.sh
+++ b/assess-tuning/set_irq_affinity.sh
@@ -1,0 +1,108 @@
+#! /bin/bash
+#
+# Copyright (c) 2017 Mellanox Technologies. All rights reserved.
+#
+# This Software is licensed under one of the following licenses:
+#
+# 1) under the terms of the "Common Public License 1.0" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/cpl.php.
+#
+# 2) under the terms of the "The BSD License" a copy of which is
+#    available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/bsd-license.php.
+#
+# 3) under the terms of the "GNU General Public License (GPL) Version 2" a
+#    copy of which is available from the Open Source Initiative, see
+#    http://www.opensource.org/licenses/gpl-license.php.
+#
+# Licensee has the right to choose one of the above licenses.
+#
+# Redistributions of source code must retain the above copyright
+# notice and one of the license notices.
+#
+# Redistributions in binary form must reproduce both the above copyright
+# notice, one of the license notices in the documentation
+# and/or other materials provided with the distribution.
+#
+if [ -z $1 ]; then
+	echo "usage: $0 <interface or IB device> [2nd interface or IB device]"
+	exit 1
+fi
+
+source common_irq_affinity.sh
+
+CORES=$((`cat /proc/cpuinfo | grep processor | tail -1 | awk '{print $3}'`+1))
+hop=1
+INT1=$1
+INT2=$2
+
+if [ -z $INT2 ]; then
+	limit_1=$CORES
+	echo "---------------------------------------"
+	echo "Optimizing IRQs for Single port traffic"
+	echo "---------------------------------------"
+else
+	echo "-------------------------------------"
+	echo "Optimizing IRQs for Dual port traffic"
+	echo "-------------------------------------"
+	limit_1=$((CORES/2))
+	limit_2=$CORES
+	IRQS_2=$( get_irq_list $INT2 )
+	if [ -z "$IRQS_2" ] ; then
+		echo No IRQs found for $INT2.
+		exit 1
+	fi
+fi
+
+IRQS_1=$( get_irq_list $INT1 )
+
+if [ -z "$IRQS_1" ] ; then
+	echo No IRQs found for $INT1.
+else
+	echo Discovered irqs for $INT1: $IRQS_1
+	core_id=0
+	for IRQ in $IRQS_1
+	do
+		if is_affinity_hint_set $IRQ ; then
+			affinity=$(cat /proc/irq/$IRQ/affinity_hint)
+			set_irq_affinity $IRQ $affinity
+			echo Assign irq $IRQ to its affinity_hint $affinity
+		else
+			echo Assign irq $IRQ core_id $core_id
+			affinity=$( core_to_affinity $core_id )
+			set_irq_affinity $IRQ $affinity
+			core_id=$(( core_id + $hop ))
+			if [ $core_id -ge $limit_1 ] ; then core_id=0; fi
+		fi
+	done
+fi
+
+echo 
+
+if [ "$INT2" != "" ]; then
+	IRQS_2=$( get_irq_list $INT2 )
+	if [ -z "$IRQS_2" ]; then
+		echo No IRQs found for $INT2.
+		exit 1
+	fi
+
+	echo Discovered irqs for $INT2: $IRQS_2
+	core_id=$limit_1
+	for IRQ in $IRQS_2
+	do
+		if is_affinity_hint_set $IRQ ; then
+			affinity=$(cat /proc/irq/$IRQ/affinity_hint)
+			set_irq_affinity $IRQ $affinity
+			echo Assign irq $IRQ to its affinity_hint $affinity
+		else
+			echo Assign irq $IRQ core_id $core_id
+			affinity=$( core_to_affinity $core_id )
+			set_irq_affinity $IRQ $affinity
+			core_id=$(( core_id + $hop ))
+			if [ $core_id -ge $limit_2 ] ; then core_id=$limit_1; fi
+		fi
+	done
+fi
+echo
+echo done.

--- a/assess-tuning/user_config.txt
+++ b/assess-tuning/user_config.txt
@@ -1,2 +1,3 @@
 apply_default_system_tuning	n
 make_default_system_tuning_perm n
+apply_nic_tuning	n

--- a/assess-tuning/user_config.txt
+++ b/assess-tuning/user_config.txt
@@ -1,3 +1,7 @@
+evaluation_timer		n	
+learning_mode_only		y
+API_listen_port			5523
+apply_bios_tuning		n
+apply_nic_tuning		n
 apply_default_system_tuning	n
 make_default_system_tuning_perm n
-apply_nic_tuning	n

--- a/packaging/createpkg.sh
+++ b/packaging/createpkg.sh
@@ -3,5 +3,7 @@ cp ../assess-tuning/dtnmenu .
 cp ../assess-tuning/dtn_menu.sh .
 cp ../assess-tuning/gdv.sh .
 cp ../assess-tuning/user_config.txt .
-zip dtntune.zip dtn_tune gdv.sh user_config.txt dtn_menu.sh dtnmenu readme.txt
+cp ../assess-tuning/common_irq_affinity.sh .
+cp ../assess-tuning/set_irq_affinity.sh .
+zip dtntune.zip dtn_tune gdv.sh user_config.txt dtn_menu.sh dtnmenu readme.txt common_irq_affinity.sh set_irq_affinity.sh
 


### PR DESCRIPTION
A bunch of tuning parameters, plus NIC configuration setting were added.  Also Additional performance tuning.
In particular for 100G NICs:

# Increase the maximum OS receive and send buffer size for all types of connections.
net.core.rmem_max = 2147483647
net.core.wmem_max = 2147483647
# The first value tells the kernel the minimum receive buffer for each TCP connection. The second value specified tells the kernel the default receive buffer allocated for each TCP socket. The third and last value specified in this variable specifies the maximum receive buffer that can be allocated for a TCP socket.
net.ipv4.tcp_rmem = 4096 87380 2147483647
net.ipv4.tcp_wmem = 4096 65536 2147483647
# Increase number of incoming connections backlog queue.
net.core.netdev_max_backlog = 250000
# Disable caching of TCP congestion state. Don't cache ssthresh from previous connection.
net.ipv4.tcp_no_metrics_save = 1
# Use the CUBIC TCP congestion control algorithm instead of the TCP Reno algorithm (Linux Kernel versions 2.6.18 and newer).
net.ipv4.tcp_congestion_control = htcp
# If you are using Jumbo Frames, ICMP black holes could occur. This setting enable a feature of the RFC4821 to detect these black holes and adjust the path MTU.
net.ipv4.tcp_mtu_probing = 1
# FQ (Fair Queuing) is recommended for CentOS7/Debian8 hosts.
net.core.default_qdisc = fq

Also consider the following sysctl parameters:

        'net.core.netdev_max_backlog' : 250000,
        'net.ipv4.tcp_no_metrics_save' : 1,


Set MTU to 9000 (is there any other indicated value?)

Setting fq as tc qdisc policy

Set the CPU Scaling Governor to Max Performance based on the Kernel current policy (powersave, performance, ondemand) instead of the current and max CPU Mhz (https://community.mellanox.com/s/article/how-to-set-cpu-scaling-governor-to-max-performance--scaling-governor-x)

Should we set specific tunings for Mellanox (and other vendors)?
 - tune_mellanox()
 - tune_dropless_rq()
 - Limiting IRQ size to number of CPU cores

Ethtool parameters like flow_control 

Disables irqbalance (systemctl stop irqbalance)

Set IRQ affinity based on NUMA node where the physical interface is allocated

Check the PCI slot for the interface (pci speed and width)

Which TCP congestion and control algorithm should we use? We are recommending Hamilton TCP, but what about Cubic, BBR, BBRv2? Maybe it will depends on the delay to the target DTN?

Check NUMA layout to validate if the interface can be better placed

Did not do specific tunings for Mellanox (and other vendors). Will address at a later time.