### PR TITLE
CPU monitoring and error msgs handling

### DIFF
--- a/userspace/user_dtn.c
+++ b/userspace/user_dtn.c
@@ -2037,7 +2037,7 @@ double fDoCpuMonitoring()
 	if (nompstat)
 		return 0;
 
-	sprintf(try,"%s","mpstat -P ALL 1 1 | grep -v all | grep -v 100.00");
+	sprintf(try,"%s","mpstat -P ALL 1 1 | grep -v all | grep -v 100.00 | grep -v 99.");
 
 	pipe = popen(try,"r");
 	if (!pipe)

--- a/userspace/userdtn_adm
+++ b/userspace/userdtn_adm
@@ -228,7 +228,7 @@ case "$1" in
         # Start the user_dtn
 	sleep 1
 	echo "Loading object and pinning map paths..."
-	bpftool prog load int-sink2+filter.bpf.o /sys/fs/bpf/test dev $nic pinmaps /sys/fs/bpf/test_maps/
+	bpftool prog load int-sink2+filter.bpf.o /sys/fs/bpf/test dev $nic pinmaps /sys/fs/bpf/test_maps/ 2>/tmp/tuningmodstart.out
 	echo "Attaching bpf program to network interface using $attach_type..."
 	bpftool net attach $attach_type pinned /sys/fs/bpf/test dev $nic
 	sleep 1


### PR DESCRIPTION
1. Cut back some of output on CPU monitoring by looking at CPUS that are being used at least 99%. Might cut this figure down in a future update.
2. On startup using bpftool to load the object code, an error may be put out which doesn't affect the operation. Now will have messages to stderr put to file /tmp/tuningmodstart.out for later review if needed 