### PR TITLE
Work on ksoftirqd

### DIFF
--- a/userspace/user_assess.c
+++ b/userspace/user_assess.c
@@ -1431,10 +1431,10 @@ void fDoShowChannels()
                                 int count = 0, ncount = 0;
                 		
 				fprintf(tunLogPtr,"%s", line);
-				continue;
 
                                 if (strstr(line,"RX:") && rxcount == 0)
                                 {
+					if (strstr(line,"n/a")) continue;
                                         rxcount++;
 
                                         while (!isdigit(line[count])) count++;
@@ -1449,6 +1449,7 @@ void fDoShowChannels()
                                 else
                                         if (strstr(line,"RX:"))
                                         {
+						if (strstr(line,"n/a")) continue;
                                                 rxcount++;
 
                                                 while (!isdigit(line[count])) count++;
@@ -1463,6 +1464,7 @@ void fDoShowChannels()
                                         else
                                                 if (strstr(line,"TX:") && txcount == 0)
 						{
+							if (strstr(line,"n/a")) continue;
                                                         txcount++;
 
                                                         while (!isdigit(line[count])) count++;
@@ -1477,6 +1479,7 @@ void fDoShowChannels()
                                                 else
                                                         if (strstr(line,"TX:"))
                                                         {
+								if (strstr(line,"n/a")) continue;
                                                                 txcount++;
 
                                                                 while (!isdigit(line[count])) count++;
@@ -1491,6 +1494,7 @@ void fDoShowChannels()
                                 			else
 								if (strstr(line,"Combined:") && combinedcount == 0)
                                 				{
+									if (strstr(line,"n/a")) continue;
                                         				combinedcount++;
 
                                         				while (!isdigit(line[count])) count++;
@@ -1505,6 +1509,7 @@ void fDoShowChannels()
                                 				else
                                         				if (strstr(line,"Combined:"))
                                         				{
+										if (strstr(line,"n/a")) continue;
                                                 				combinedcount++;
 	
        					                                        while (!isdigit(line[count])) count++;
@@ -1531,7 +1536,7 @@ void fDoShowChannels()
 
                                                                 		netDevice_tx_channel_cfg_max_val = atoi(sTXMAXValue);
                                                                			netDevice_tx_channel_cfg_curr_val = atoi(sTXCURRValue);
-                                                                
+										
                                                                 		//should be the last thing I need
                                                                 		break;
                                         				}
@@ -1549,10 +1554,7 @@ void fDoShowChannels()
 	return;
 
 dnrb_support:
-        vPad = SETTINGS_PAD_MAX-(strlen("ring_buffer_rx_tx"));
-        fprintf(tunLogPtr,"%s", "ring_buffer_rx_tx"); //redundancy for visual
-        fprintf(tunLogPtr,"%*s", vPad, "not supported");
-        fprintf(tunLogPtr,"%26s %20s\n", "not supported", "na");
+        fprintf(tunLogPtr,"****ethtool -l not supported\n");
         system("rm -f /tmp/NIC.cfgfile"); //remove file after use
 
         return;

--- a/userspace/user_dtn.c
+++ b/userspace/user_dtn.c
@@ -2745,18 +2745,23 @@ void fDoSetChannels(void)
 					current_phase = TUNING;
 					fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s\n", 
 														ms_ctime_buf, phase2str(current_phase),  buffer);
+					fprintf(tunLogPtr,"%s %s: ***WARNING: Also, please make sure you are running your application using a core in the Nic's NUMA***\n",
+														ms_ctime_buf, phase2str(current_phase));
 					system(buffer);
 					vDidSetChannel = 1;
 					current_phase = LEARNING;
 				}
 				else
 					{
-						fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
+						fprintf(tunLogPtr,"%s %s: ***WARNING: Please make sure you are running your application using a core in the Nic's NUMA***\n",
+														ms_ctime_buf, phase2str(current_phase));
+						fprintf(tunLogPtr,"%s %s: ***WARNING: If the above is true, please run the following command to fix ksoftirqd resource issue::: %s\n", 
 														ms_ctime_buf, phase2str(current_phase),  buffer);
 					}
 			}
 			else
 				{
+#if 0
 					sprintf(buffer,"ethtool -L %s combined %d",netDevice, combined_to_use);
 					if (gTuningMode && current_phase == LEARNING) //need to fix so that current_phase always has the right mode
 					{
@@ -2772,11 +2777,17 @@ void fDoSetChannels(void)
 							fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
 															ms_ctime_buf, phase2str(current_phase),  buffer);
 						}
+#endif
+					fprintf(tunLogPtr,"%s %s: ***WARNING: No known fix for ksoftirqd issue on this NIC at this point:::\n", ms_ctime_buf, phase2str(current_phase));
+					fprintf(tunLogPtr,"%s %s: ***WARNING: Please use tools like \"ethtool -L and/or ethtool -X\" to see if you can resolve this issue:::\n", ms_ctime_buf, phase2str(current_phase));
+					fprintf(tunLogPtr,"%s %s: ***WARNING: Also, please make sure you are running your application using a core in the Nic's NUMA***\n", ms_ctime_buf, phase2str(current_phase));
 				}
 		}
 		else
 			{
 				fprintf(tunLogPtr,"%s %s: ***WARNING: can't fix ksoftirqd resource issue with ethtool command at this point***\n", 
+															ms_ctime_buf, phase2str(current_phase));
+				fprintf(tunLogPtr,"%s %s: ***WARNING: However, please make sure you are running your application using a core in the Nic's NUMA***\n",
 															ms_ctime_buf, phase2str(current_phase));
 			}
 	 }
@@ -2796,18 +2807,23 @@ void fDoSetChannels(void)
 						current_phase = TUNING;
 						fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s\n", 
 														ms_ctime_buf, phase2str(current_phase),  buffer);
+						fprintf(tunLogPtr,"%s %s: ***WARNING: Also, please make sure you are running your application using a core in the Nic's NUMA***\n",
+																ms_ctime_buf, phase2str(current_phase));
 						system(buffer);
 						vDidSetChannel = 1;
 						current_phase = LEARNING;
 					}
 					else
 						{
-							fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
+							fprintf(tunLogPtr,"%s %s: ***WARNING: Please make sure you are running your application using a core in the Nic's NUMA***\n",
+														ms_ctime_buf, phase2str(current_phase));
+							fprintf(tunLogPtr,"%s %s: ***WARNING: If the above is true, please run the following command to fix ksoftirqd resource issue::: %s\n", 
 														ms_ctime_buf, phase2str(current_phase),  buffer);
 						}
 				}
 				else
 					{
+#if 0
 						sprintf(buffer,"ethtool -L %s combined %d",netDevice, combined_to_use);
 						if (gTuningMode && (current_phase == LEARNING)) //need to fix so that current_phase always has the right mode
 						{
@@ -2823,6 +2839,12 @@ void fDoSetChannels(void)
 								fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
 															ms_ctime_buf, phase2str(current_phase), buffer);
 							}
+#endif
+						fprintf(tunLogPtr,"%s %s: ***WARNING: No known fix for ksoftirqd issue on this NIC at this point:::\n", ms_ctime_buf, phase2str(current_phase));
+						fprintf(tunLogPtr,"%s %s: ***WARNING: Please use tools like \"ethtool -L and/or ethtool -X\" to see if you can resolve this issue:::\n", 
+																			ms_ctime_buf, phase2str(current_phase));
+						fprintf(tunLogPtr,"%s %s: ***WARNING: Also, please make sure you are running your application using a core in the Nic's NUMA***\n",
+																			ms_ctime_buf, phase2str(current_phase));
 					}
 			}
 		}

--- a/userspace/user_dtn.c
+++ b/userspace/user_dtn.c
@@ -2710,18 +2710,39 @@ void fDoSetChannels(void)
 			if (!netDevice_only_combined_channel_cfg)
 			{
 				sprintf(buffer,"ethtool -L %s rx 0 tx %d  combined %d",netDevice, tx_to_use, combined_to_use);
-				fprintf(tunLogPtr,"%s %s: ***WARNING: run the following command to get rid of ksoftirqd resource issue::: %s", ms_ctime_buf, phase2str(current_phase),  buffer);
+				if (gTuningMode) //need to fix so that current_phase always has the right mode
+				{
+					fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s", 
+														ms_ctime_buf, "TUNING",  buffer);
+					system(buffer);
+				}
+				else
+					{
+						fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
+															ms_ctime_buf, phase2str(current_phase),  buffer);
+					}
 			}
 			else
 				{
 					sprintf(buffer,"ethtool -L %s combined %d",netDevice, combined_to_use);
-					fprintf(tunLogPtr,"%s %s: ***WARNING: run the following command to get rid of ksoftirqd resource issue::: %s", ms_ctime_buf, phase2str(current_phase),  buffer);
+					if (gTuningMode) //need to fix so that current_phase always has the right mode
+					{
+						fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s", 
+																ms_ctime_buf, "TUNING",  buffer);
+						system(buffer);
+					}
+					else
+						{
+							fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
+															ms_ctime_buf, phase2str(current_phase),  buffer);
+						}
 				}
 		}
 		else
-		{
-			fprintf(tunLogPtr,"%s %s: ***WARNING: can't fix ksoftirqd resource issue with ethtool command at this point***", ms_ctime_buf, phase2str(current_phase));
-		}
+			{
+				fprintf(tunLogPtr,"%s %s: ***WARNING: can't fix ksoftirqd resource issue with ethtool command at this point***", 
+															ms_ctime_buf, phase2str(current_phase));
+			}
 	}
 	else
 		if (nProc)
@@ -2734,14 +2755,32 @@ void fDoSetChannels(void)
 				if (!netDevice_only_combined_channel_cfg)
 				{
 					sprintf(buffer,"ethtool -L %s rx 0 tx %d  combined %d",netDevice, tx_to_use, combined_to_use);
-					fprintf(tunLogPtr,"%s %s: ***WARNING: run the following command to get rid of ksoftirqd resource issue::: %s", 
+					if (gTuningMode) //need to fix so that current_phase always has the right mode
+					{
+						fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s", 
+														ms_ctime_buf, phase2str(current_phase),  buffer);
+						system(buffer);
+					}
+					else
+						{
+							fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
 															ms_ctime_buf, phase2str(current_phase),  buffer);
+						}
 				}
 				else
 					{
 						sprintf(buffer,"ethtool -L %s combined %d",netDevice, combined_to_use);
-						fprintf(tunLogPtr,"%s %s: ***WARNING: run the following command to get rid of ksoftirqd resource issue::: %s", 
-															ms_ctime_buf, phase2str(current_phase),  buffer);
+						if (gTuningMode) //need to fix so that current_phase always has the right mode
+						{
+							fprintf(tunLogPtr,"%s %s: ***WARNING: running the following command to fix ksoftirqd resource issue::: %s", 
+															ms_ctime_buf, "TUNING",  buffer);
+							system(buffer);
+						}
+						else
+							{	
+								fprintf(tunLogPtr,"%s %s: ***WARNING: please run the following command to fix ksoftirqd resource issue::: %s\n", 
+																		ms_ctime_buf, "TUNING",  buffer);
+							}
 					}
 			}
 		}

--- a/userspace/user_dtn.c
+++ b/userspace/user_dtn.c
@@ -2730,6 +2730,8 @@ void fDoCheckSoftirqd(void)
                 {
 			gettimeWithMilli(&clk, ctime_buf, ms_ctime_buf);
 			fprintf(tunLogPtr,"%s %s: ***WARNING ksoftirqd is using >= 60%c of CPU resources::: %s", ms_ctime_buf, phase2str(current_phase), '%', buffer);
+			
+			//sudo ethtool -L netro-switch rx 0 tx 28  combined 4
 		}
 		else
 			continue;

--- a/userspace/user_dtn.h
+++ b/userspace/user_dtn.h
@@ -52,6 +52,16 @@ extern void fDoNicTuning(void);
 extern void fDoSystemtuning(void);
 extern void fDo_lshw(void);
 extern void fCheck_log_limit(void);
+extern int fDoGetNproc(void);
+extern int nProc;
+
+extern int netDevice_rx_channel_cfg_max_val;
+extern int netDevice_tx_channel_cfg_max_val;
+extern int netDevice_combined_channel_cfg_max_val;
+extern int netDevice_rx_channel_cfg_curr_val;
+extern int netDevice_tx_channel_cfg_curr_val;
+extern int netDevice_combined_channel_cfg_curr_val;
+extern int netDevice_only_combined_channel_cfg;
 
 extern void Pthread_mutex_lock(pthread_mutex_t *);
 extern void Pthread_mutex_unlock(pthread_mutex_t *);


### PR DESCRIPTION
Fixed the issue when the kernel thread  "ksoftirqd" has a high CPU usage (> 60% in our case) when using the Netronome NIC. However,  when using the Mellanox NIC, was not able to reliably lower the usage when the issue occurs. Tried setting complete IRQ affinity (RSS) and various commands using ethtool -L and ethtool -X using weights and combinations. Perhaps the problem is with the driver or firmware of he card or with the version of Linux kernel that we are reusing. Will revisit using Mellanox at a later date. 